### PR TITLE
fix(gulp): dist js should be in a closure

### DIFF
--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -37,7 +37,7 @@ gulp.task "clean", ->
 gulp.task "coffee", ->
   gulp
     .src "./src/*.coffee"
-    .pipe coffee bare: true
+    .pipe coffee()
     .pipe gulp.dest distDir
   gulp
     .src 'test/**/*.coffee'


### PR DESCRIPTION
This will allow us to not expose multiple properties on the global scope. :+1: :fireworks: 
